### PR TITLE
Reduce carousel image size in ContainerDetails

### DIFF
--- a/src/pages/ContainerDetails.tsx
+++ b/src/pages/ContainerDetails.tsx
@@ -149,7 +149,7 @@ const ContainerDetails: React.FC = () => {
                       <img
                         src={img.url}
                         alt={`Imagem ${idx + 1}`}
-                        className="w-full h-48 object-cover transition-transform duration-300 group-hover:scale-105 cursor-pointer"
+                        className="w-full h-32 object-cover transition-transform duration-300 group-hover:scale-105 cursor-pointer"
                       />
                       <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-colors duration-300 flex items-center justify-center">
                         <svg className="w-6 h-6 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- shrink carousel image height on ContainerDetails page for a more compact layout

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5e4ef4f4833189370e06ab6ab593